### PR TITLE
Improved iohook_test.js

### DIFF
--- a/iohook_test.js
+++ b/iohook_test.js
@@ -25,10 +25,11 @@ ioHook.start();
 // Key constants
 const CTRL = 29;
 const ALT = 56;
+const TAB = 15;
 const F7 = 65;
 
 // Registers shortcut
-ioHook.registerShortcut([CTRL, F7], (keys) => {
+ioHook.registerShortcut([ALT, TAB], (keys) => {
   console.log('Shortcut pressed with keys:', keys);
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "7.0.66",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.66.tgz",
-      "integrity": "sha512-W11u5kUNSX2+N6bJ7rPyLW4N98/xzrZg8apRoTwC0zbFjIie//oxgKAvqkQNQ97KVchB49ost74kgzoeDiE+Uw=="
+      "version": "7.0.67",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.67.tgz",
+      "integrity": "sha512-DUioEWBd0NG30G1/wI0amNN/sSJ/xuX4/YWm4nNa+bUU6swuS7CF+sH/nifu+SPy5BFqRzQEyEWvi9zIDVP+Lw=="
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -167,7 +167,7 @@
       "resolved": "https://registry.npmjs.org/iohook/-/iohook-0.2.0.tgz",
       "integrity": "sha512-P6dqN69pSzDR0TTjgytE1yhTYGr0mRvpP2wf+WnfGd6dclxSxEoMYC8uCrOZW7T8JOzhr+RoNIJdJVhlB+edbw==",
       "requires": {
-        "@types/node": "7.0.66",
+        "@types/node": "7.0.67",
         "bindings": "1.3.0",
         "node-abi": "2.4.3",
         "pump": "1.0.3",


### PR DESCRIPTION
Confirmed iohook library does not support stpping keyboard event propagation